### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/Junction.css
+++ b/webfonts/Junction.css
@@ -1,0 +1,16 @@
+/*
+  'Junction'
+  https://www.theleagueofmoveabletype.com/junction
+
+  Copyright (c) 2010, Caroline Hadilaksono <caroline@hadilaksono.com>, with Reserved Font Name: "Junction".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Junction';
+  src: url('Junction-webfont.eot?#iefix') format('embedded-opentype'),
+       url('Junction-webfont.woff') format('woff'),
+       url('Junction-webfont.ttf')  format('truetype'),
+       url('Junction-webfont.svg#webfont2B4HRL5F') format('svg');
+}

--- a/webfonts/Junction.css
+++ b/webfonts/Junction.css
@@ -9,6 +9,7 @@
 */
 @font-face {
   font-family: 'Junction';
+  src: url('Junction-webfont.eot'),
   src: url('Junction-webfont.eot?#iefix') format('embedded-opentype'),
        url('Junction-webfont.woff') format('woff'),
        url('Junction-webfont.ttf')  format('truetype'),

--- a/webfonts/Junction.css
+++ b/webfonts/Junction.css
@@ -9,7 +9,7 @@
 */
 @font-face {
   font-family: 'Junction';
-  src: url('Junction-webfont.eot'),
+  src: url('Junction-webfont.eot');
   src: url('Junction-webfont.eot?#iefix') format('embedded-opentype'),
        url('Junction-webfont.woff') format('woff'),
        url('Junction-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
